### PR TITLE
Added method and unittest for valuesWithPrefix

### DIFF
--- a/LWTrie/LWTrie.h
+++ b/LWTrie/LWTrie.h
@@ -30,4 +30,9 @@
 
 /// Dump some stats info to the console.
 - (void)stats;
+
+/**
+ * Returns the values of a node with a given prefix and all descendants
+ */
+- (NSArray *)valuesWithPrefix:(NSString *)prefix;
 @end

--- a/LWTrie/LWTrie.m
+++ b/LWTrie/LWTrie.m
@@ -308,6 +308,32 @@
     }
 }
 
+- (NSArray *)valuesWithPrefix:(NSString *)prefix{
+
+    NSMutableArray* valueList = [[NSMutableArray alloc]init];
+    LWTrieNode *node = [self.root find:prefix startingAt:0];
+
+    if (node) {
+        [self addValuesFromDescendantsOfNode:node toArray:valueList];
+    }else{
+        NSLog(@"Error: Node not found for prefix: %@", prefix);
+    }
+
+    return valueList;
+}
+
+- (void)addValuesFromDescendantsOfNode:(LWTrieNode *)node toArray:(NSMutableArray *)valueList{
+
+    [valueList addObject:node->item];
+
+    if ([node hasChildren]) {
+        for (NSNumber* child in node.children) {
+            LWTrieNode *childNode = [node getChildForKey:child];
+            [self addValuesFromDescendantsOfNode:childNode toArray:valueList];
+        }
+    }
+}
+
 #pragma mark - NSCoding protocol
 
 #define kRoot @"r"

--- a/LWTrieTests/LWTrieTest.m
+++ b/LWTrieTests/LWTrieTest.m
@@ -153,6 +153,32 @@
     XCTAssertNil(result, @"'ho' not nil");
 }
 
+- (void)testvaluesWithPrefix{
+    [_trie insert:@"hi" value:@1];
+    [_trie insert:@"howdy" value:@2];
+    [_trie insert:@"how" value:@3];
+    [_trie insert:@"howard" value:@4];
+    [_trie insert:@"howards" value:@5];
+    [_trie insert:@"hola" value:@6];
+
+    [_trie stats];
+
+    NSString *str = @"how";
+
+    NSArray *valuelist = [_trie valuesWithPrefix:str];
+
+    NSLog(@"%lu nodes in array", [valuelist count]);
+
+    XCTAssertEqual([valuelist count], 4);
+    XCTAssertTrue([valuelist containsObject:@2]);
+    XCTAssertTrue([valuelist containsObject:@3]);
+    XCTAssertTrue([valuelist containsObject:@4]);
+    XCTAssertTrue([valuelist containsObject:@5]);
+
+    XCTAssertFalse([valuelist containsObject:@1]);
+    XCTAssertFalse([valuelist containsObject:@6]);
+}
+
 # pragma mark - utilities
 
 - (void)writeBinaryPlist:(NSDictionary *)dict path:(NSString *)path {


### PR DESCRIPTION
Created a method that finds a node based on a given prefix, then returns an array containing that node's value and the values of that node's descendants.
